### PR TITLE
Removes spec for overridable function

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -150,7 +150,6 @@ defmodule Phoenix.Template do
       By default it raises but can be customized
       to render a particular template.
       """
-      @spec template_not_found(Phoenix.Template.name(), map) :: no_return
       def template_not_found(template, assigns) do
         Template.raise_template_not_found(__MODULE__, template, assigns)
       end

--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -150,6 +150,9 @@ defmodule Phoenix.Template do
       By default it raises but can be customized
       to render a particular template.
       """
+      # Do not add a spec as they are not overridable and
+      # the user may want to return an actual value
+      # @spec template_not_found(Phoenix.Template.name(), map) :: no_return
       def template_not_found(template, assigns) do
         Template.raise_template_not_found(__MODULE__, template, assigns)
       end


### PR DESCRIPTION
This spec was introduced in https://github.com/phoenixframework/phoenix/pull/1583 to fix dialyzer warning on the freshly generated phoenix app. But it became impossible to override the spec in the application code

See discussion in https://github.com/elixir-lang/elixir/issues/11574

/cc @josevalim 