### PR TITLE
Fix syntax error in documentation

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -334,7 +334,7 @@ defmodule Phoenix.View do
   in the sidebar. Inside your sidebar, you could do:
 
       <div class="sidebar">
-        <%= if function_exported?(view_module(@conn), :sidebar_additions, 1) do
+        <%= if function_exported?(view_module(@conn), :sidebar_additions, 1) do %>
           <%= view_module(@conn).sidebar_additions(assigns) %>
         <% end %>
       </div>

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -343,7 +343,7 @@ defmodule Phoenix.View do
   accessing the view under `@socket`:
 
       <div class="sidebar">
-        <%= if function_exported?(@socket.view, :sidebar_additions, 1) do
+        <%= if function_exported?(@socket.view, :sidebar_additions, 1) do %>
           <%= @socket.view.sidebar_additions(assigns) %>
         <% end %>
       </div>


### PR DESCRIPTION
Just fixing a little typo I found while copying the code sample.