### PR TITLE
Bump Elixir to 1.4 and Erlang/OTP to 25 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
               elixir: '1.9'
               otp: 20
           - pair:
-              elixir: '1.12'
-              otp: 24
+              elixir: '1.14'
+              otp: 25
             lint: lint
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Testing

A run on Github Actions was performed successfully https://github.com/szymon-jez/phoenix_view/actions/runs/3338054827 [![CI](https://github.com/szymon-jez/phoenix_view/actions/workflows/ci.yml/badge.svg?branch=patch-2)](https://github.com/szymon-jez/phoenix_view/actions/workflows/ci.yml)