### PR TITLE
Add leading underscore in "Migrating to Phoenix.Component"

### DIFF
--- a/lib/phoenix_view.ex
+++ b/lib/phoenix_view.ex
@@ -157,7 +157,7 @@ defmodule Phoenix.View do
     3. Your templates may now break if they are calling `render/2`.
        You can address this by replacing `render/2` with a function
        component. For instance, `render("_form.html", changeset: @changeset, user: @user)`
-       must now be called as `<.form changeset={@changeset} user={@user} />`.
+       must now be called as `<._form changeset={@changeset} user={@user} />`.
        If passing all assigns, `render("_form.html", assigns)` becomes
        `<%= _form(assigns) %>`
 


### PR DESCRIPTION
I was migrating from Phoenix.View to Phoenix.Component and was stumped why my `_post` partial would not work when typing `<.post ...>`, even though I followed the docs exactly. I then tried it in a brand new app, where it also didn't work.

After looking at the `embed_templates` function, I realized that I need a leading underscore, which is probably missing accidentally? It's there in the next sentence (`<%= _form(assigns) %>`), so I assume this was a minor oversight.