### PR TITLE
Fix warning in elixir 1.7

### DIFF
--- a/lib/phoenix_view.ex
+++ b/lib/phoenix_view.ex
@@ -562,7 +562,7 @@ defmodule Phoenix.View do
   defp get_resource_name(assigns, view) do
     case assigns do
       %{as: as} -> as
-      _ -> view.__resource__
+      _ -> view.__resource__()
     end
   end
 


### PR DESCRIPTION
Fix warning like : 
using map.field notation (without parentheses) to invoke function ... parentheses instead: remote.function()