### PR TITLE
Release v2.0.4?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.4 (2024-06-14)
+
+  * Fix warning when using elixir v1.17
+
 ## 2.0.3 (2023-10-28)
 
   * Relax Phoenix.HTML dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.3 (2023-10-28)
+
+  * Relax Phoenix.HTML dependency
+
 ## 2.0.2 (2022-11-07)
 
   * Fix regression where directories were not being tracked for new files

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixView.MixProject do
   use Mix.Project
 
-  @version "2.0.3"
+  @version "2.0.4"
   @source_url "https://github.com/phoenixframework/phoenix_view"
 
   def project do


### PR DESCRIPTION
This PR:

- bumps the version number to v2.0.4
- adds a changelog entry for it
- cherry-picks jose's commit adding the v2.0.3 changelog (which somehow got left out of `main`)

I set the release date to tomorrow because obviously I don't have the keys to actually do a release and it's already late (here, at least).